### PR TITLE
README.mdの誤字を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ tinder_engine
 ### 1. 必要なパッケージをインストール
 
 ```
-pip instal -r requirements.txt
+pip install -r requirements.txt
 ```
 
 ### 2. `modules`フォルダに`config.py`を作成する


### PR DESCRIPTION
```
pip instal -r requirements.txt
```
を
```
pip install -r requirements.txt
```
に修正